### PR TITLE
preserve link text with break all

### DIFF
--- a/lib/util/link.ts
+++ b/lib/util/link.ts
@@ -12,6 +12,6 @@ export function replaceURLsWithLink(text) {
 
   return text.replace(
     urlRegex,
-    '<a style="text-decoration:underline;" href="$1" target="_blank" rel="noopener noreferrer">*link*</a>'
+    '<a style="word-break: break-all; text-decoration:underline" href=$1 target="_blank" rel="noopener noreferrer">$1</a>'
   );
 }


### PR DESCRIPTION
Before we were replacing links with just "link" but we can conditionally apply "break all" and improve 