### PR TITLE
Make the title a link to the prop

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -67,9 +67,16 @@ export default function Home({ openProposals, fallback }: HomePageProps) {
         </div>
         <div className="md:w-2/3 md:ml-auto">
           <h1 className="text-3xl font-semibold  m-4 px-2 pt-2">
-            {selectedProposal
-              ? `${selectedProposal.id}: ${selectedProposal.title}`
-              : 'Vote Timeline'}
+            {selectedProposal ? (
+              <a
+                href={`https://nouns.wtf/vote/${selectedProposal.id}`}
+                target="_blank"
+              >
+                {selectedProposal.id}: ${selectedProposal.title}
+              </a>
+            ) : (
+              'Vote Timeline'
+            )}
           </h1>
           <div className="flex flex-wrap justify-left m-4">
             {selectedProposal ? (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -71,6 +71,8 @@ export default function Home({ openProposals, fallback }: HomePageProps) {
               <a
                 href={`https://nouns.wtf/vote/${selectedProposal.id}`}
                 target="_blank"
+                rel="noreferrer"
+                className="hover:underline"
               >
                 {selectedProposal.id}: ${selectedProposal.title}
               </a>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -10,6 +10,7 @@ import { unstable_serialize } from 'swr/infinite';
 import { Proposal } from '../types/Proposal';
 import axios from 'axios';
 import { getProposals } from '../lib/proposals';
+import { getNounsLink } from '../lib/util/link';
 
 type HomePageProps = {
   fallback: FallbackProp;
@@ -69,7 +70,7 @@ export default function Home({ openProposals, fallback }: HomePageProps) {
           <h1 className="text-3xl font-semibold  m-4 px-2 pt-2">
             {selectedProposal ? (
               <a
-                href={`https://nouns.wtf/vote/${selectedProposal.id}`}
+                href={getNounsLink(selectedProposal.id)}
                 target="_blank"
                 rel="noreferrer"
                 className="hover:underline"


### PR DESCRIPTION
This is for when a proposal has been selected (i.e. `selectedProposal === true`). It would be nice for the user to just click the big heading and have the proposal open up.