### PR TITLE
feat: nns resolver

### DIFF
--- a/components/VoteReasons.tsx
+++ b/components/VoteReasons.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { useAccount } from 'wagmi';
+import { useAccount, usePublicClient } from 'wagmi';
 import { useWalletClient } from 'wagmi';
 import { getNounsLink } from '../lib/util/link';
 import { clsx as classNames } from 'clsx';
@@ -15,6 +15,7 @@ import { ArrowPathIcon } from '@heroicons/react/24/outline';
 import { useVoteDetail } from '../hooks/useVoteDetail';
 import { useShowVoteModal } from '../hooks/useShowVoteModal';
 import { useVotableProposals } from '../hooks/useVotableProposals';
+import { slice, fromHex } from 'viem';
 
 interface VoteReasonProps {
   vote: Vote;
@@ -38,6 +39,29 @@ export function VoteReasons({ vote }: VoteReasonProps) {
     if (!proposals || !vote.proposal.id) return false;
     return proposals.some(p => p.id === vote.proposal.id);
   }, [proposals, vote.proposal.id]);
+
+  const publicClient = usePublicClient();
+  const [nnsName, setNnsName] = useState<string | null>(null);
+
+  useEffect(() => {
+    const getNnsName = async () => {
+      try {
+        const calldata = '55ea6c47000000000000000000000000' + vote.voter.id.substring(2);
+        const res = await publicClient.call({
+          data: `0x${calldata}`,
+          to: '0x849f92178950f6254db5d16d1ba265e70521ac1b',
+        });
+        const offset = Number(BigInt(slice(res.data!, 0, 32)));
+        const length = Number(BigInt(slice(res.data!, offset, offset + 32)));
+        const name = fromHex(slice(res.data!, offset + 32, offset + 32 + length), 'string') || null;
+        // console.log(name);
+        setNnsName(name);
+      } catch (error) {
+        // console.log('Error getting NNS name:', error);
+      }
+    };
+    getNnsName();
+  }, []);
 
   const ensName = useMemo(
     () => (vote.voter.ensName ? vote.voter.ensName : vote.voter.id.slice(0, 8)),
@@ -101,9 +125,8 @@ export function VoteReasons({ vote }: VoteReasonProps) {
   return (
     <div>
       <div
-        className={`flex  p-3 mb-2 ${
-          vote.reason ? 'bg-gray-800' : ''
-        } rounded-lg shadow-md`}
+        className={`flex  p-3 mb-2 ${vote.reason ? 'bg-gray-800' : ''
+          } rounded-lg shadow-md`}
       >
         <div className="mr-2">
           <Link href={`/voters/${encodeURIComponent(vote.voter.id)}`}>
@@ -123,7 +146,7 @@ export function VoteReasons({ vote }: VoteReasonProps) {
               className="hover:underline"
               href={`/voters/${encodeURIComponent(vote.voter.id)}`}
             >
-              {ensName}
+              {nnsName ? nnsName : ensName}
             </Link>
             {'  '}
             <span
@@ -139,8 +162,8 @@ export function VoteReasons({ vote }: VoteReasonProps) {
               {vote.supportDetailed == 1
                 ? 'FOR'
                 : vote.supportDetailed == 0
-                ? 'AGAINST'
-                : 'ABSTAIN'}{' '}
+                  ? 'AGAINST'
+                  : 'ABSTAIN'}{' '}
             </span>
             <span className="text-gray-500 mx-1"> · </span>
             <TimeAgo
@@ -184,11 +207,10 @@ export function VoteReasons({ vote }: VoteReasonProps) {
               <button
                 onClick={handleLikeClick}
                 disabled={!walletClient || liked}
-                className={` ${
-                  liked
-                    ? ''
-                    : 'transition duration-300 ease-in-out hover:bg-red-500 rounded-full'
-                }`}
+                className={` ${liked
+                  ? ''
+                  : 'transition duration-300 ease-in-out hover:bg-red-500 rounded-full'
+                  }`}
               >
                 {liked ? (
                   <Image
@@ -207,11 +229,10 @@ export function VoteReasons({ vote }: VoteReasonProps) {
                 )}
               </button>
               <p
-                className={`ml-1 mb-1 font-semibold ${
-                  voterLikes.length + nonVoterLikes.length == 0
-                    ? 'text-gray-800'
-                    : 'text-gray-500'
-                }`}
+                className={`ml-1 mb-1 font-semibold ${voterLikes.length + nonVoterLikes.length == 0
+                  ? 'text-gray-800'
+                  : 'text-gray-500'
+                  }`}
               >
                 {voterLikes.length + nonVoterLikes.length}
               </p>


### PR DESCRIPTION
As part of the initiatives to add NNS resolving to different apps in the ecosystem, this pull request added NNS resolving using contract calls.

The original plan was to use the native `getEnsName` method in `viem` to resolve NNS names with a drop-in replacement of the NNS resolver address, but unexpected errors arise. Hence, the contract call method from [nnsprotocol/nns-resolver-demo](https://github.com/nnsprotocol/nns-resolver-demo/blob/main/src/examples/ethers.js#L24) is used instead.

The contract call method is definitely less efficient, but it will always fall back to the original resolved ENS name from Basement while loading or if NNS doesn't exist.